### PR TITLE
Correcting relative path for file enum and adding table of encoders

### DIFF
--- a/lessons/FileEnumeration/setup/src/index.cfm
+++ b/lessons/FileEnumeration/setup/src/index.cfm
@@ -14,13 +14,13 @@
 				<h3>Your personal files are ready for download</h3>
 				<br />
 				
-				<a href="userfiles/user005/016.txt">File_016</a><br />
-				<a href="userfiles/user005/019.txt">File_019</a><br />
-				<a href="userfiles/user005/012.txt">File_012</a><br />
-				<a href="userfiles/user005/011.txt">File_011</a><br />
-				<a href="userfiles/user005/008.txt">File_008</a><br />
-				<a href="userfiles/user005/002.txt">File_002</a><br />
-				<a href="userfiles/user005/001.txt">File_001</a><br />
+				<a href="../userfiles/user005/016.txt">File_016</a><br />
+				<a href="../userfiles/user005/019.txt">File_019</a><br />
+				<a href="../userfiles/user005/012.txt">File_012</a><br />
+				<a href="../userfiles/user005/011.txt">File_011</a><br />
+				<a href="../userfiles/user005/008.txt">File_008</a><br />
+				<a href="../userfiles/user005/002.txt">File_002</a><br />
+				<a href="../userfiles/user005/001.txt">File_001</a><br />
 			</div>
 		  
 		</div>

--- a/tags/layout.cfm
+++ b/tags/layout.cfm
@@ -51,6 +51,7 @@
 	            <li class="dropdown<cfif attributes.activeMenu IS "tools"> active</cfif>">
                 <a href="/tools/http.cfm" class="dropdown-toggle" data-toggle="dropdown">Tools <b class="caret"></b></a>
                 <ul class="dropdown-menu">
+                  <li><a href="/tools/encoders.cfm">Encoders</a></li>
                   <li><a href="/tools/http.cfm">HTTP Util</a></li>
                   <li class="divider"></li>
                   <li class="dropdown-header">Regex Tools</li>

--- a/tools/encoders.cfm
+++ b/tools/encoders.cfm
@@ -1,0 +1,51 @@
+<cf_layout activeMenu="tools">
+	
+<h1>ASCII 0 - 255</h1>
+<table id="encoders" class="table table-striped table-bordered table-hover" style="font-size: 90%;">
+    <thead>
+        <tr>
+            <th rowspan="2">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</th>
+            <th colspan="3" class="success">HTML</th>
+            <th colspan="3" class="warning">XML</th>
+            <th colspan="2" class="danger">URL</th>
+            <th colspan="2" class="info">JS</th>
+            <th class="active">CSS</th>
+        </tr>
+        <tr>
+            <th class="success">htmlEditFormat</th>
+            <th class="success">encodeForHTML</th>
+            <th class="success">encodeForHTMLAttribute</th>
+            <th class="warning">xmlFormat</th>
+            <th class="warning">encodeForXML</th>
+            <th class="warning">encodeForXMLAttribute</th>
+            <th class="danger">urlEncodedFormat</th>
+            <th class="danger">encodeForURL</th>
+            <th class="info">jsStringFormat</th>
+            <th class="info">encodeForJavascript</th>
+            <th class="active">encodeForCSS</th>
+        </tr>
+    </thead>
+    <tbody>
+        <cfloop from="0" to="255" index="variables.index">
+        <cfoutput>
+        <tr>
+            <td>#variables.index# : #chr(variables.index)#</td>
+            <td class="success">#replace(htmlEditFormat(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="success">#replace(encodeForHTML(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="success">#replace(encodeForHTMLAttribute(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="warning">#replace(xmlFormat(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="warning">#replace(encodeForXML(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="warning">#replace(encodeForXMLAttribute(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="danger">#replace(urlEncodedFormat(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="danger">#replace(encodeForURL(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="info">#replace(jsStringFormat(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="info">#replace(encodeForJavascript(chr(variables.index)), "&", "&amp;")#</td>
+            <td class="active">#replace(encodeForCSS(chr(variables.index)), "&", "&amp;")#</td>
+        </tr>
+        </cfoutput>
+        </cfloop>
+    </tbody>
+</table>
+
+
+</cf_layout>


### PR DESCRIPTION
So file enumeration will generate 404 because userfiles are never moved into playground folder, so correcting the links so it works.

Adding an encoders page to tools to show how various ColdFusion functions encode ASCII characters 0-255. Will help explain XSS better and why using newer functions from ESAPI should be used.
