### PR TITLE
Updated lesson set up to work with Windows path separators

### DIFF
--- a/components/Lesson.cfc
+++ b/components/Lesson.cfc
@@ -1,7 +1,7 @@
 <cfcomponent displayname="Lesson Component" hint="All Lessons should extend this one">
 	<cfset variables.lessonName = "Undefined">
 	<cfset variables.configuration = "">
-	
+
 	<cffunction name="init" returntype="Lesson" output="false" hint="I am called when a new instance of a Lesson is invoked">
 		<cfargument name="configuration" type="any" required="true">
 		<cfset var componentName = GetMetaData(this).name>
@@ -11,7 +11,7 @@
 		<cfset variables.configuration = arguments.configuration>
 		<cfreturn this>
 	</cffunction>
-	
+
 	<cffunction name="reset" returntype="void" output="false" hint="I reset a lesson">
 		<cfset setup()>
 	</cffunction>
@@ -19,13 +19,13 @@
 	<cffunction name="getName" returntype="string" output="false" hint="I return the Name of the lesson">
 		<cfreturn variables.lessonName>
 	</cffunction>
-	
+
 	<cffunction name="setup" access="public" returntype="void" output="false">
-		
+
 		<cfset copyLessonSourceFiles()>
-		
+
 	</cffunction>
-	
+
 	<cffunction name="copyLessonSourceFiles" returntype="void" access="package" output="false" hint="I copy files from setup/src in to the root of the lesson dir.">
 		<cfset var dir = "" />
 		<cfset var lessonDir = getLessonDirectory()>
@@ -45,14 +45,14 @@
 		</cfif>
 		--->
 	</cffunction>
-	
+
 	<cffunction name="getLessonDirectory" returntype="string" output="false" hint="I return the lesson directory path, eg: /lessons/lessonName/">
-		<cfreturn ReplaceNoCase(GetCurrentTemplatePath(), "setup/" & ListLast(GetCurrentTemplatePath(), "/"), "")>
+		<cfreturn ReReplaceNoCase(GetDirectoryFromPath(GetCurrentTemplatePath()), "setup[\\/]", "")>
 	</cffunction>
-	
+
 	<cffunction name="getConfiguration" returntype="Configuration" output="false" access="public" hint="I return the config bean">
 		<cfreturn variables.configuration>
 	</cffunction>
 
 </cfcomponent>
-	
+


### PR DESCRIPTION
I ran into a problem where the lesson playground directory would not auto initialize due to a replace on the setup path looking only for a "/". Here's the fix I implemented to get this working under Windows if you want to review and pull into your repo.
